### PR TITLE
Emit vscode-uri as umd

### DIFF
--- a/spec/tsconfig.json
+++ b/spec/tsconfig.json
@@ -1,5 +1,6 @@
 {
     "compilerOptions": {
-        "target": "es5"
+        "target": "es5",
+        "module": "umd"
     }
 }


### PR DESCRIPTION
So I can also use it in the standalone editor..

Looks like there are two tsconfig files. One has umd, one not. 
