### PR TITLE
fix: remove broken esm bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "description": "The URI implementation that is used by VS Code and its extensions",
   "main": "./lib/umd/index.js",
   "typings": "./lib/umd/index",
-  "module": "./lib/esm/index.js",
   "sideEffects": false,
   "scripts": {
     "clean": "rimraf lib",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,82 +5,37 @@
 
 const path = require('path');
 
-module.exports = [
-    // UMD
-    {
-        mode: 'none',
-        entry: './src/index.ts',
-        resolve: {
-            mainFields: ['module', 'main'],
-            extensions: ['.ts', '.js'], // support ts-files and js-files
-            fallback: {
-                path: require.resolve('path-browserify')
-            }
-        },
-        output: {
-            libraryTarget: 'umd',
-            globalObject: 'this',
-            path: path.resolve(__dirname, 'lib', 'umd'),
-            filename: 'index.js'
-        },
-        module: {
-            rules: [{
-                test: /\.ts$/,
-                exclude: /node_modules/,
-                use: [{
-                    // configure TypeScript loader:
-                    // * enable sources maps for end-to-end source maps
-                    loader: 'ts-loader',
-                    options: {
-                        compilerOptions: {
-                            'sourceMap': true,
-                        }
-                    }
-                }]
-            }]
-        },
-        devtool: 'source-map'
+module.exports = {
+    mode: 'none',
+    entry: './src/index.ts',
+    resolve: {
+        mainFields: ['module', 'main'],
+        extensions: ['.ts', '.js'], // support ts-files and js-files
+        fallback: {
+            path: require.resolve('path-browserify')
+        }
     },
-    // ESM
-    {
-        mode: 'none',
-        entry: './src/index.ts',
-        resolve: {
-            mainFields: ['module', 'main'],
-            extensions: ['.ts', '.js'], // support ts-files and js-files
-            fallback: {
-                path: require.resolve('path-browserify')
-            }
-        },
-        output: {
-            library: 'LIB',
-            libraryTarget: 'var',
-            path: path.resolve(__dirname, 'lib', 'esm'),
-            filename: 'index.js'
-        },
-        module: {
-            rules: [{
-                test: /\.ts$/,
-                exclude: /node_modules/,
-                use: [{
-                    // configure TypeScript loader:
-                    // * enable sources maps for end-to-end source maps
-                    loader: 'ts-loader',
-                    options: {
-                        compilerOptions: {
-                            sourceMap: true,
-                            target: 'es5',
-                            forceConsistentCasingInFileNames: true,
-                            noImplicitAny: true,
-                            module: 'es6',
-                            lib: [
-                                'es2015'
-                            ]
-                        }
+    output: {
+        libraryTarget: 'umd',
+        globalObject: 'this',
+        path: path.resolve(__dirname, 'lib', 'umd'),
+        filename: 'index.js'
+    },
+    module: {
+        rules: [{
+            test: /\.ts$/,
+            exclude: /node_modules/,
+            use: [{
+                // configure TypeScript loader:
+                // * enable sources maps for end-to-end source maps
+                loader: 'ts-loader',
+                options: {
+                    compilerOptions: {
+                        'sourceMap': true,
                     }
-                }]
+                }
             }]
-        },
-        devtool: 'source-map'
-    }
-]
+        }]
+    },
+    devtool: 'source-map'
+}


### PR DESCRIPTION
since moving to webpack5, and the removal of esm-webpack-plugin, the esm bundle has been broken.

When bundling the following:
```ts
import { URI } from 'vscode-uri';
console.log(URI);
```

`undefined` is printed.

@aeschli any chance issues are re-enabled in this repository so such things can be reported/discussed?