### PR TITLE
vscode-uri (3.0.5): Incorrect Types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-uri",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-uri",
-      "version": "3.0.5",
+      "version": "3.0.6",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^9.1.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vscode-uri",
   "author": "Microsoft",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "description": "The URI implementation that is used by VS Code and its extensions",
   "main": "./lib/umd/index.js",
   "typings": "./lib/umd/index",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -74,6 +74,7 @@ module.exports = [
                             forceConsistentCasingInFileNames: true,
                             noImplicitAny: true,
                             module: 'es6',
+                            declaration: false,
                             lib: [
                                 'es2015'
                             ]


### PR DESCRIPTION
 Fixes microsoft/vscode#161166

Looks like a change in webpack caused this [rule](https://github.com/microsoft/vscode-uri/blob/be2c3de41709c7523b3cee89513c9e20d99da03b/webpack.config.js#L90) also to be applied for the d.ts file