### PR TITLE
Restore the default export

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,3 +8,4 @@ import { URI } from './uri';
 import { Utils } from './utils';
 
 export { URI, Utils }
+export default { URI, Utils }


### PR DESCRIPTION
A fairly recent release fixed the ESM dual publishing situation. This broke ESM apps that relied on `vscode-uri` being CJS. On such project is `vscode-markdown-languageservice`. This change fixes that by adding a default export that contains all named exports.

Fixes https://github.com/microsoft/vscode-markdown-languageservice/issues/250